### PR TITLE
Import subcrates through the main crate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ shell: build-dev
 
 .PHONY: build-ci
 build-ci: build-dev
-	IMAGE=$(IMAGE) ./docker/run.sh cargo build
+	IMAGE=$(IMAGE) ./docker/run.sh cargo build --tests
 	sudo chmod -R ugo+rwx ./build-cache
 	docker save "$(IMAGE)" | gzip > ./build-cache/docker-image.tar.gz
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ both complex and straightforward use cases.
 ## Basic Usage
 
 ```rust
-use front_line_router::{FrontLine, HttpVersion, RouterResult, Router};
+use front_line::{FrontLine, HttpVersion, RouterResult, Router};
 
 #[derive(FrontLine)]
 enum MarketingRoutes {

--- a/front-line-derive/Cargo.toml
+++ b/front-line-derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "front-line-derive"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Derive proc-macros for the front-line http router"
 repository = "https://github.com/plasmaconduit/front-line/"
-readme = "../README.md"
+readme = "README.md"
 
 [lib]
 proc-macro = true
@@ -15,7 +15,3 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 regex = { workspace = true }
 syn = { workspace = true }
-
-[dev-dependencies]
-front-line-router = { path = "../front-line-router" }
-rstest = { workspace = true }

--- a/front-line-derive/README.md
+++ b/front-line-derive/README.md
@@ -1,0 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [DO NOT USE DIRECTLY](#do-not-use-directly)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# DO NOT USE DIRECTLY
+
+import and use `front-line` instead.

--- a/front-line-derive/src/capture_fields.rs
+++ b/front-line-derive/src/capture_fields.rs
@@ -42,7 +42,7 @@ impl<'a> CaptureFields<'a> {
             let parsed = format_ident!("parsed{base_offset}_{ident}");
             let converted = format_ident!("converted{base_offset}_{ident}");
             let conversion = quote! {
-                let #parsed: Option<#ty> = front_line_router::FromRoute::parse_path_variable(&#capture);
+                let #parsed: Option<#ty> = front_line::FromRoute::parse_path_variable(&#capture);
                 if #parsed.is_none() {
                     break #path_block;
                 }

--- a/front-line-derive/src/lib.rs
+++ b/front-line-derive/src/lib.rs
@@ -1,3 +1,6 @@
+//! Do not import or use this crate directly, import and use `front-line` instead.
+//! See: [front-line](https://docs.rs/front-line/latest/front_line/)
+
 mod capture_fields;
 mod method_tag;
 mod path;
@@ -56,9 +59,9 @@ pub fn front_line_derive(input: TokenStream) -> TokenStream {
                 })
                 .collect();
             let router = quote! {
-                impl<#extended_params> front_line_router::Router<'de> for #name<#params> {
+                impl<#extended_params> front_line::Router<'de> for #name<#params> {
                       fn handle_parsed(
-                        #method: front_line_router::Method,
+                        #method: front_line::Method,
                         #remaining_path: &'de str
                     ) -> Option<Self> {
                         #prefix_matcher

--- a/front-line-derive/src/path.rs
+++ b/front-line-derive/src/path.rs
@@ -77,7 +77,7 @@ impl Path {
                     let end = format_ident!("end{segment_offset}");
                     let capture = format_ident!("capture{base_offset}_{variable}");
                     quote! {
-                        let #end = front_line_router::memchr::memchr(b'/', #last_slice.as_bytes()).unwrap_or(#last_slice.len());
+                        let #end = front_line::memchr::memchr(b'/', #last_slice.as_bytes()).unwrap_or(#last_slice.len());
                         let #capture = &#last_slice[..#end];
                         let #next_slice = &#last_slice[#end..];
                     }

--- a/front-line-derive/src/variant_type.rs
+++ b/front-line-derive/src/variant_type.rs
@@ -47,7 +47,7 @@ impl<'a> VariantType<'a> {
                         .collect();
                     let method_ident = method.to_ident();
                     let by_method_matcher = quote! {
-                        if #parsed_method == front_line_router::Method::#method_ident {
+                        if #parsed_method == front_line::Method::#method_ident {
                             #(
                                 #path_blocks
                             )*

--- a/front-line-router/Cargo.toml
+++ b/front-line-router/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "front-line-router"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "Traits and utilities for the front-line http router"
 repository = "https://github.com/plasmaconduit/front-line/"
-readme = "../README.md"
+readme = "README.md"
 
 [dependencies]
 memchr = { workspace = true }

--- a/front-line-router/README.md
+++ b/front-line-router/README.md
@@ -1,0 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [DO NOT USE DIRECTLY](#do-not-use-directly)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# DO NOT USE DIRECTLY
+
+import and use [front-line](https://crates.io/crates/front-line) instead.

--- a/front-line-router/src/lib.rs
+++ b/front-line-router/src/lib.rs
@@ -1,3 +1,6 @@
+//! Do not import or use this crate directly, import and use `front-line` instead.
+//! See: [front-line](https://docs.rs/front-line/latest/front_line/)
+
 mod from_route;
 mod http_version;
 mod method;

--- a/front-line/Cargo.toml
+++ b/front-line/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "front-line"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A declarative, zero-copy HTTP router"
@@ -10,3 +10,8 @@ readme = "../README.md"
 [dependencies]
 front-line-router = { version = "0.1.0" }
 front-line-derive = { version = "0.1.0"}
+#front-line-router = { path = "../front-line-router" }
+#front-line-derive = { path = "../front-line-derive"}
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/front-line/tests/front_line_tests.rs
+++ b/front-line/tests/front_line_tests.rs
@@ -1,5 +1,4 @@
-use front_line_derive::FrontLine;
-use front_line_router::{Error, HttpVersion, Router, RouterResult};
+use front_line::{Error, FrontLine, HttpVersion, Router, RouterResult};
 use rstest::rstest;
 
 #[derive(PartialEq, Debug, FrontLine)]


### PR DESCRIPTION
The macro derive crate was generating code importing from the router crate directly but the user is expected to import the main crate, not the sub-crates