### PR TITLE
Bump re-exports to 0.2.0

### DIFF
--- a/front-line/Cargo.toml
+++ b/front-line/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/plasmaconduit/front-line/"
 readme = "../README.md"
 
 [dependencies]
-front-line-router = { version = "0.1.0" }
-front-line-derive = { version = "0.1.0"}
+front-line-router = { version = "0.2.0" }
+front-line-derive = { version = "0.2.0"}
 #front-line-router = { path = "../front-line-router" }
 #front-line-derive = { path = "../front-line-derive"}
 


### PR DESCRIPTION
Bumps re-exports to 0.2.0, this is effectively a publish event